### PR TITLE
Add import traversal as optional behavior

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,13 +18,14 @@ const ignoreNode = "";
 export interface ICompilerOptions {
   ignoreGenerics?: boolean;
   ignoreIndexSignature?: boolean;
+  traverseImports?: boolean;
 }
 
 // The main public interface is `Compiler.compile`.
 export class Compiler {
   public static compile(
       filePath: string,
-      options: ICompilerOptions = {ignoreGenerics: false, ignoreIndexSignature: false},
+      options: ICompilerOptions = { ignoreGenerics: false, ignoreIndexSignature: false, traverseImports: false},
     ): string {
     const createProgramOptions = {target: ts.ScriptTarget.Latest, module: ts.ModuleKind.CommonJS};
     const program = ts.createProgram([filePath], createProgramOptions);
@@ -198,6 +199,9 @@ export class Compiler {
     return this.compileNode(node.type);
   }
   private _compileImportDeclaration(node: ts.ImportDeclaration): string {
+    if (!this.options.traverseImports) {
+      return '';
+    }
     const importedSym = this.checker.getSymbolAtLocation(node.moduleSpecifier);
     if (importedSym && importedSym.declarations) {
       return importedSym.declarations.map(declaration => this.compileNode(declaration)).join("");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,7 +25,7 @@ export interface ICompilerOptions {
 export class Compiler {
   public static compile(
       filePath: string,
-      options: ICompilerOptions = { ignoreGenerics: false, ignoreIndexSignature: false, traverseImports: false},
+      options: ICompilerOptions = {ignoreGenerics: false, ignoreIndexSignature: false, traverseImports: false},
     ): string {
     const createProgramOptions = {target: ts.ScriptTarget.Latest, module: ts.ModuleKind.CommonJS};
     const program = ts.createProgram([filePath], createProgramOptions);
@@ -199,12 +199,14 @@ export class Compiler {
     return this.compileNode(node.type);
   }
   private _compileImportDeclaration(node: ts.ImportDeclaration): string {
-    if (!this.options.traverseImports) {
-      return '';
-    }
-    const importedSym = this.checker.getSymbolAtLocation(node.moduleSpecifier);
-    if (importedSym && importedSym.declarations) {
-      return importedSym.declarations.map(declaration => this.compileNode(declaration)).join("");
+    if (this.options.traverseImports) {
+      const importedSym = this.checker.getSymbolAtLocation(node.moduleSpecifier);
+      if (importedSym && importedSym.declarations) {
+        // this._compileSourceFile will get called on every imported file when traversing imports. 
+        // it's important to check that _compileSourceFile is being run against the topNode 
+        // before adding the file wrapper for this reason.
+        return importedSym.declarations.map(declaration => this.compileNode(declaration)).join("");
+      }
     }
     return '';
   }

--- a/test/fixtures/imports-child-a.ts
+++ b/test/fixtures/imports-child-a.ts
@@ -1,0 +1,1 @@
+export interface TypeA {};

--- a/test/fixtures/imports-child-b.ts
+++ b/test/fixtures/imports-child-b.ts
@@ -1,0 +1,8 @@
+export interface TypeB { };
+
+// import and export on separate lines
+import { TypeC } from './imports-child-c';
+export { TypeC };
+
+// inline export shorthand
+export { TypeD } from './imports-child-d';

--- a/test/fixtures/imports-child-c.ts
+++ b/test/fixtures/imports-child-c.ts
@@ -1,0 +1,1 @@
+export interface TypeC {};

--- a/test/fixtures/imports-child-d.ts
+++ b/test/fixtures/imports-child-d.ts
@@ -1,0 +1,1 @@
+export interface TypeD {};

--- a/test/fixtures/imports-parent-shallow-ti.ts
+++ b/test/fixtures/imports-parent-shallow-ti.ts
@@ -1,0 +1,14 @@
+import * as t from "ts-interface-checker";
+// tslint:disable:object-literal-key-quotes
+
+export const TypeAll = t.iface([], {
+  "a": "TypeA",
+  "b": "TypeB",
+  "c": "TypeC",
+  "d": "TypeD",
+});
+
+const exportedTypeSuite: t.ITypeSuite = {
+  TypeAll,
+};
+export default exportedTypeSuite;

--- a/test/fixtures/imports-parent-ti.ts
+++ b/test/fixtures/imports-parent-ti.ts
@@ -1,0 +1,30 @@
+import * as t from "ts-interface-checker";
+// tslint:disable:object-literal-key-quotes
+
+export const TypeA = t.iface([], {
+});
+
+export const TypeB = t.iface([], {
+});
+
+export const TypeC = t.iface([], {
+});
+
+export const TypeD = t.iface([], {
+});
+
+export const TypeAll = t.iface([], {
+  "a": "TypeA",
+  "b": "TypeB",
+  "c": "TypeC",
+  "d": "TypeD",
+});
+
+const exportedTypeSuite: t.ITypeSuite = {
+  TypeA,
+  TypeB,
+  TypeC,
+  TypeD,
+  TypeAll,
+};
+export default exportedTypeSuite;

--- a/test/fixtures/imports-parent.ts
+++ b/test/fixtures/imports-parent.ts
@@ -1,0 +1,9 @@
+import { TypeA } from './imports-child-a';
+import { TypeB, TypeC, TypeD } from './imports-child-b';
+
+export interface TypeAll {
+  a: TypeA,
+  b: TypeB,
+  c: TypeC,
+  d: TypeD
+}

--- a/test/test_index.ts
+++ b/test/test_index.ts
@@ -37,4 +37,10 @@ describe("ts-interface-builder", () => {
     const expected = await readFile(join(fixtures, "array-ti.ts"), {encoding: "utf8"});
     assert.deepEqual(output, expected);
   });
+
+  it("should traverse imports", async () => {
+    const output = await Compiler.compile(join(fixtures, "imports-parent.ts"));
+    const expected = await readFile(join(fixtures, "imports-parent-ti.ts"), { encoding: "utf8" });
+    assert.deepEqual(output, expected);
+  });
 });

--- a/test/test_index.ts
+++ b/test/test_index.ts
@@ -39,8 +39,15 @@ describe("ts-interface-builder", () => {
   });
 
   it("should traverse imports", async () => {
-    const output = await Compiler.compile(join(fixtures, "imports-parent.ts"));
+    const output = await Compiler.compile(join(fixtures, "imports-parent.ts"),
+      {traverseImports: true});
     const expected = await readFile(join(fixtures, "imports-parent-ti.ts"), { encoding: "utf8" });
+    assert.deepEqual(output, expected);
+  });
+
+  it("should not traverse imports when option is not set", async () => {
+    const output = await Compiler.compile(join(fixtures, "imports-parent.ts"));
+    const expected = await readFile(join(fixtures, "imports-parent-shallow-ti.ts"), { encoding: "utf8" });
     assert.deepEqual(output, expected);
   });
 });


### PR DESCRIPTION
**Why:** In developing using the ts-interface-checker, we got to a point where we wanted to use some imported types alongside a check. This didn't work in the current setup because the AST parsing logic ignores all imports and exports.

This code adds logic that handles imports and exports (because `export { ... } from '...'` is also a valid import syntax in ES modules) by passing their loading their symbols and passing their declarations through `this.compileNode`. The result is that every declaration inside of the imported class will be concatenated into the final `-ti.ts` file. I took my inspiration on how this code is written up from this GH Issues comment: https://github.com/Microsoft/TypeScript/issues/23195#issuecomment-379296283

Obviously, not everyone will want this feature, but it's critical for us, so I've implemented it as an option that's off by default. I could see inverting that in a future major version perhaps, especially if tree-shaking were to be implemented.