### PR TITLE
Add traverse imports to the CLI args

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -262,6 +262,7 @@ export function main() {
   .usage("[options] <typescript-file...>")
   .option("-g, --ignore-generics", `Ignores generics`)
   .option("-i, --ignore-index-signature", `Ignores index signature`)
+  .option("-t, --traverse-imports", `Traverses the full import tree and inlines all types into output`)
   .option("-s, --suffix <suffix>", `Suffix to append to generated files (default ${defaultSuffix})`, defaultSuffix)
   .option("-o, --outDir <path>", `Directory for output files; same as source file if omitted`)
   .option("-v, --verbose", "Produce verbose output")
@@ -274,6 +275,7 @@ export function main() {
   const options: ICompilerOptions = {
     ignoreGenerics: commander.ignoreGenerics,
     ignoreIndexSignature: commander.ignoreIndexSignature,
+    traverseImports: commander.traverseImports,
   };
 
   if (files.length === 0) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,14 +18,14 @@ const ignoreNode = "";
 export interface ICompilerOptions {
   ignoreGenerics?: boolean;
   ignoreIndexSignature?: boolean;
-  traverseImports?: boolean;
+  inlineImports?: boolean;
 }
 
 // The main public interface is `Compiler.compile`.
 export class Compiler {
   public static compile(
       filePath: string,
-      options: ICompilerOptions = {ignoreGenerics: false, ignoreIndexSignature: false, traverseImports: false},
+      options: ICompilerOptions = {ignoreGenerics: false, ignoreIndexSignature: false, inlineImports: false},
     ): string {
     const createProgramOptions = {target: ts.ScriptTarget.Latest, module: ts.ModuleKind.CommonJS};
     const program = ts.createProgram([filePath], createProgramOptions);
@@ -199,7 +199,7 @@ export class Compiler {
     return this.compileNode(node.type);
   }
   private _compileImportDeclaration(node: ts.ImportDeclaration): string {
-    if (this.options.traverseImports) {
+    if (this.options.inlineImports) {
       const importedSym = this.checker.getSymbolAtLocation(node.moduleSpecifier);
       if (importedSym && importedSym.declarations) {
         // this._compileSourceFile will get called on every imported file when traversing imports. 
@@ -262,7 +262,7 @@ export function main() {
   .usage("[options] <typescript-file...>")
   .option("-g, --ignore-generics", `Ignores generics`)
   .option("-i, --ignore-index-signature", `Ignores index signature`)
-  .option("-t, --traverse-imports", `Traverses the full import tree and inlines all types into output`)
+  .option("--inline-imports", `Traverses the full import tree and inlines all types into output`)
   .option("-s, --suffix <suffix>", `Suffix to append to generated files (default ${defaultSuffix})`, defaultSuffix)
   .option("-o, --outDir <path>", `Directory for output files; same as source file if omitted`)
   .option("-v, --verbose", "Produce verbose output")
@@ -275,7 +275,7 @@ export function main() {
   const options: ICompilerOptions = {
     ignoreGenerics: commander.ignoreGenerics,
     ignoreIndexSignature: commander.ignoreIndexSignature,
-    traverseImports: commander.traverseImports,
+    inlineImports: commander.inlineImports,
   };
 
   if (files.length === 0) {

--- a/test/test_index.ts
+++ b/test/test_index.ts
@@ -38,14 +38,14 @@ describe("ts-interface-builder", () => {
     assert.deepEqual(output, expected);
   });
 
-  it("should traverse imports", async () => {
+  it("should inline imports", async () => {
     const output = await Compiler.compile(join(fixtures, "imports-parent.ts"),
-      {traverseImports: true});
+      {inlineImports: true});
     const expected = await readFile(join(fixtures, "imports-parent-ti.ts"), { encoding: "utf8" });
     assert.deepEqual(output, expected);
   });
 
-  it("should not traverse imports when option is not set", async () => {
+  it("should not inline imports when option is not set", async () => {
     const output = await Compiler.compile(join(fixtures, "imports-parent.ts"));
     const expected = await readFile(join(fixtures, "imports-parent-shallow-ti.ts"), { encoding: "utf8" });
     assert.deepEqual(output, expected);


### PR DESCRIPTION
@dsagal, sorry for the quick follow-up:

I realized that I never included the CLI arg for the new option (we call `Compiler.compile` programmatically). I'm debating whether it should be `-r` (recursive traversal, like `cp -r` or something), but I also think I'm overthinking it.