### PR TITLE
Ignore literal index signatures

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -145,7 +145,10 @@ export class Compiler {
     return `t.func(${items.join(", ")})`;
   }
   private _compileTypeLiteralNode(node: ts.TypeLiteralNode): string {
-    const members = node.members.map((n) => "  " + this.indent(this.compileNode(n)) + ",\n");
+    const members = node.members
+      .map(n => this.compileNode(n))
+      .filter(n => n !== ignoreNode)
+      .map(n => "  " + this.indent(n) + ",\n");
     return `t.iface([], {\n${members.join("")}})`;
   }
   private _compileArrayTypeNode(node: ts.ArrayTypeNode): string {
@@ -172,9 +175,9 @@ export class Compiler {
   private _compileInterfaceDeclaration(node: ts.InterfaceDeclaration): string {
     const name = this.getName(node.name);
     const members = node.members
-      .map((n) => this.compileNode(n))
-      .filter((n) => n !== ignoreNode)
-      .map((n) => "  " + this.indent(n) + ",\n");
+      .map(n => this.compileNode(n))
+      .filter(n => n !== ignoreNode)
+      .map(n => "  " + this.indent(n) + ",\n");
     const extend: string[] = [];
     if (node.heritageClauses) {
       for (const h of node.heritageClauses) {

--- a/test/fixtures/ignore-index-signature-ti.ts
+++ b/test/fixtures/ignore-index-signature-ti.ts
@@ -4,7 +4,13 @@ import * as t from "ts-interface-checker";
 export const ITest = t.iface([], {
 });
 
+export const INestedLiteralIndexSignature = t.iface([], {
+  "nestedIndexSignature": t.iface([], {
+  }),
+});
+
 const exportedTypeSuite: t.ITypeSuite = {
   ITest,
+  INestedLiteralIndexSignature,
 };
 export default exportedTypeSuite;

--- a/test/fixtures/ignore-index-signature.ts
+++ b/test/fixtures/ignore-index-signature.ts
@@ -1,3 +1,9 @@
 export interface ITest {
     [extra: string]: any;
 }
+
+export interface INestedLiteralIndexSignature {
+    nestedIndexSignature: {
+        [key: string]: string | number | boolean;
+    }
+}


### PR DESCRIPTION
There's a bug currently where nested literal index signatures would emit
invalid typescrit of the form `mykey: {,}`. This change makes it so that
index signatures in type literals and interface definitions are treated
the same.

Closes https://github.com/gristlabs/ts-interface-builder/issues/10.