### PR TITLE
Support optionals in tuples

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -62,7 +62,7 @@ export class Compiler {
       case ts.SyntaxKind.TupleType: return this._compileTupleTypeNode(node as ts.TupleTypeNode);
       case ts.SyntaxKind.UnionType: return this._compileUnionTypeNode(node as ts.UnionTypeNode);
       case ts.SyntaxKind.LiteralType: return this._compileLiteralTypeNode(node as ts.LiteralTypeNode);
-      case ts.SyntaxKind.JSDocNullableType: return this._compileJSDocNullableType(node as ts.JSDocNullableType);
+      case ts.SyntaxKind.OptionalType: return this._compileOptionalTypeNode(node as ts.OptionalTypeNode);
       case ts.SyntaxKind.EnumDeclaration: return this._compileEnumDeclaration(node as ts.EnumDeclaration);
       case ts.SyntaxKind.InterfaceDeclaration:
         return this._compileInterfaceDeclaration(node as ts.InterfaceDeclaration);
@@ -163,7 +163,7 @@ export class Compiler {
   private _compileLiteralTypeNode(node: ts.LiteralTypeNode): string {
     return `t.lit(${node.getText()})`;
   }
-  private _compileJSDocNullableType(node: ts.JSDocNullableType): string {
+  private _compileOptionalTypeNode(node: ts.OptionalTypeNode): string {
     return `t.opt(${this.compileOptType(node.type)})`;
   }
   private _compileEnumDeclaration(node: ts.EnumDeclaration): string {
@@ -206,8 +206,8 @@ export class Compiler {
     if (this.options.inlineImports) {
       const importedSym = this.checker.getSymbolAtLocation(node.moduleSpecifier);
       if (importedSym && importedSym.declarations) {
-        // this._compileSourceFile will get called on every imported file when traversing imports. 
-        // it's important to check that _compileSourceFile is being run against the topNode 
+        // this._compileSourceFile will get called on every imported file when traversing imports.
+        // it's important to check that _compileSourceFile is being run against the topNode
         // before adding the file wrapper for this reason.
         return importedSym.declarations.map(declaration => this.compileNode(declaration)).join("");
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -164,7 +164,7 @@ export class Compiler {
     return `t.lit(${node.getText()})`;
   }
   private _compileOptionalTypeNode(node: ts.OptionalTypeNode): string {
-    return `t.opt(${this.compileOptType(node.type)})`;
+    return `t.opt(${this.compileNode(node.type)})`;
   }
   private _compileEnumDeclaration(node: ts.EnumDeclaration): string {
     const name = this.getName(node.name);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -62,6 +62,7 @@ export class Compiler {
       case ts.SyntaxKind.TupleType: return this._compileTupleTypeNode(node as ts.TupleTypeNode);
       case ts.SyntaxKind.UnionType: return this._compileUnionTypeNode(node as ts.UnionTypeNode);
       case ts.SyntaxKind.LiteralType: return this._compileLiteralTypeNode(node as ts.LiteralTypeNode);
+      case ts.SyntaxKind.JSDocNullableType: return this._compileJSDocNullableType(node as ts.JSDocNullableType);
       case ts.SyntaxKind.EnumDeclaration: return this._compileEnumDeclaration(node as ts.EnumDeclaration);
       case ts.SyntaxKind.InterfaceDeclaration:
         return this._compileInterfaceDeclaration(node as ts.InterfaceDeclaration);
@@ -161,6 +162,9 @@ export class Compiler {
   }
   private _compileLiteralTypeNode(node: ts.LiteralTypeNode): string {
     return `t.lit(${node.getText()})`;
+  }
+  private _compileJSDocNullableType(node: ts.JSDocNullableType): string {
+    return `t.opt(${this.compileOptType(node.type)})`;
   }
   private _compileEnumDeclaration(node: ts.EnumDeclaration): string {
     const name = this.getName(node.name);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "commander": "^2.12.2",
     "fs-extra": "^4.0.3",
-    "typescript": "^2.6.2"
+    "typescript": "^3.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^4.0.5",

--- a/test/fixtures/array-ti.ts
+++ b/test/fixtures/array-ti.ts
@@ -7,6 +7,10 @@ export const IMyArrayContainer = t.iface([], {
     "foo": "string",
     "bar": "number",
   })),
+  "myArray3": t.array("number"),
+  "myArray4": t.tuple("number"),
+  "myArray5": t.tuple("number", "number"),
+  "myArray6": t.tuple("number", t.union("number", "undefined")),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/test/fixtures/array-ti.ts
+++ b/test/fixtures/array-ti.ts
@@ -11,6 +11,7 @@ export const IMyArrayContainer = t.iface([], {
   "myArray4": t.tuple("number"),
   "myArray5": t.tuple("number", "number"),
   "myArray6": t.tuple("number", t.union("number", "undefined")),
+  "myArray7": t.tuple("number", t.opt("number")),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/test/fixtures/array.ts
+++ b/test/fixtures/array.ts
@@ -5,4 +5,5 @@ export interface IMyArrayContainer {
   myArray4: [number];
   myArray5: [number, number];
   myArray6: [number, number | undefined];
+  myArray7: [number, number?];
 }

--- a/test/fixtures/array.ts
+++ b/test/fixtures/array.ts
@@ -1,4 +1,8 @@
 export interface IMyArrayContainer {
   myArray: Array<number>;
   myArray2: Array<{foo: string, bar: number}>;
+  myArray3: number[];
+  myArray4: [number];
+  myArray5: [number, number];
+  myArray6: [number, number | undefined];
 }


### PR DESCRIPTION
Closes #16 

I think this will work if https://github.com/gristlabs/ts-interface-checker is also updated and `t.opt` is supported in `t.tuple`