### PR TITLE
Add `format?: "ts" | "js:esm" | "js:cjs"` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save ts-interface-checker
 
 This module works together with [ts-interface-checker](https://github.com/gristlabs/ts-interface-checker) module. You use
 `ts-interface-builder` in a build step that converts some TypeScript interfaces
-to a new TypeScript file (with `-ti.ts` extension) that provides a runtime
+to a new TypeScript or JavaScript file (with `-ti.ts` or `-ti.js` extension) that provides a runtime
 description of the interface. You then use `ts-interface-checker` in your
 program to create validator functions from this runtime description.
 
@@ -48,7 +48,7 @@ Then you can generate code for runtime checks with:
 
 It produces a file like this:
 ```typescript
-// foo-ti.js
+// foo-ti.ts
 import * as t from "ts-interface-checker";
 
 export const Square = t.iface([], {
@@ -56,7 +56,10 @@ export const Square = t.iface([], {
   "color": t.opt("string"),
 });
 
-export default ...;
+const exportedTypeSuite: t.ITypeSuite = {
+  Square,
+};
+export default exportedTypeSuite;
 ```
 
 See [ts-interface-checker](https://github.com/gristlabs/ts-interface-checker) module for how to use this file in your program.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,8 @@ import * as fs from "fs";
 import * as path from "path";
 import * as ts from "typescript";
 
+// Default format to use for `format` option
+const defaultFormat = "ts"
 // Default suffix appended to generated files. Abbreviation for "ts-interface".
 const defaultSuffix = "-ti";
 // Default header prepended to the generated module.
@@ -16,6 +18,7 @@ const defaultHeader =
 const ignoreNode = "";
 
 export interface ICompilerOptions {
+  format?: "ts" | "js:esm" | "js:cjs"
   ignoreGenerics?: boolean;
   ignoreIndexSignature?: boolean;
   inlineImports?: boolean;
@@ -25,7 +28,7 @@ export interface ICompilerOptions {
 export class Compiler {
   public static compile(
       filePath: string,
-      options: ICompilerOptions = {ignoreGenerics: false, ignoreIndexSignature: false, inlineImports: false},
+      options: ICompilerOptions = {},
     ): string {
     const createProgramOptions = {target: ts.ScriptTarget.Latest, module: ts.ModuleKind.CommonJS};
     const program = ts.createProgram([filePath], createProgramOptions);
@@ -34,6 +37,7 @@ export class Compiler {
     if (!topNode) {
       throw new Error(`Can't process ${filePath}: ${collectDiagnostics(program)}`);
     }
+    options = {format: defaultFormat, ignoreGenerics: false, ignoreIndexSignature: false, inlineImports: false, ...options}
     return new Compiler(checker, options, topNode).compileNode(topNode);
   }
 
@@ -179,7 +183,7 @@ export class Compiler {
     const members: string[] = node.members.map(m =>
       `  "${this.getName(m.name)}": ${getTextOfConstantValue(this.checker.getConstantValue(m))},\n`);
     this.exportedNames.push(name);
-    return `export const ${name} = t.enumtype({\n${members.join("")}});`;
+    return this._formatExport(name, `t.enumtype({\n${members.join("")}})`);
   }
   private _compileInterfaceDeclaration(node: ts.InterfaceDeclaration): string {
     const name = this.getName(node.name);
@@ -194,7 +198,7 @@ export class Compiler {
       }
     }
     this.exportedNames.push(name);
-    return `export const ${name} = t.iface([${extend.join(", ")}], {\n${members.join("")}});`;
+    return this._formatExport(name, `t.iface([${extend.join(", ")}], {\n${members.join("")}})`)
   }
   private _compileTypeAliasDeclaration(node: ts.TypeAliasDeclaration): string {
     const name = this.getName(node.name);
@@ -202,7 +206,7 @@ export class Compiler {
     const compiled = this.compileNode(node.type);
     // Turn string literals into explicit `name` nodes, as expected by ITypeSuite.
     const fullType = compiled.startsWith('"') ? `t.name(${compiled})` : compiled;
-    return `export const ${name} = ${fullType};`;
+    return this._formatExport(name, fullType)
   }
   private _compileExpressionWithTypeArguments(node: ts.ExpressionWithTypeArguments): string {
     return this.compileNode(node.expression);
@@ -231,11 +235,18 @@ export class Compiler {
       return this._compileSourceFileStatements(node);
     }
     // wrap the top node with a default export
+    if (this.options.format === "js:cjs") {
+      return `const t = require("ts-interface-checker");\n\n` +
+        "module.exports = {\n" +
+        this._compileSourceFileStatements(node) + "\n" +
+        "};\n"
+    }
     const prefix = `import * as t from "ts-interface-checker";\n` +
-                   "// tslint:disable:object-literal-key-quotes\n\n";
+                   (this.options.format === "ts" ? "// tslint:disable:object-literal-key-quotes\n" : "") +
+                   "\n";
     return prefix +
       this._compileSourceFileStatements(node) + "\n\n" +
-      "const exportedTypeSuite: t.ITypeSuite = {\n" +
+      "const exportedTypeSuite" + (this.options.format === "ts" ? ": t.ITypeSuite" : "") + " = {\n" +
       this.exportedNames.map((n) => `  ${n},\n`).join("") +
       "};\n" +
       "export default exportedTypeSuite;\n";
@@ -247,6 +258,11 @@ export class Compiler {
 
     throw new Error(`Node ${ts.SyntaxKind[node.kind]} not supported by ts-interface-builder: ` +
       node.getText());
+  }
+  private _formatExport(name: string, expression: string): string {
+    return this.options.format === "js:cjs"
+        ? `  ${name}: ${this.indent(expression)},`
+        : `export const ${name} = ${expression};`;
   }
 }
 
@@ -272,6 +288,7 @@ export function main() {
   commander
   .description("Create runtime validator module from TypeScript interfaces")
   .usage("[options] <typescript-file...>")
+  .option("--format <format>", `Format to use for output; options are 'ts', 'js:esm', 'js:cjs'`)
   .option("-g, --ignore-generics", `Ignores generics`)
   .option("-i, --ignore-index-signature", `Ignores index signature`)
   .option("--inline-imports", `Traverses the full import tree and inlines all types into output`)
@@ -285,6 +302,7 @@ export function main() {
   const suffix: string = commander.suffix;
   const outDir: string|undefined = commander.outDir;
   const options: ICompilerOptions = {
+    format: commander.format || defaultFormat,
     ignoreGenerics: commander.ignoreGenerics,
     ignoreIndexSignature: commander.ignoreIndexSignature,
     inlineImports: commander.inlineImports,
@@ -300,7 +318,7 @@ export function main() {
     // Read and parse the source file.
     const ext = path.extname(filePath);
     const dir = outDir || path.dirname(filePath);
-    const outPath = path.join(dir, path.basename(filePath, ext) + suffix + ".ts");
+    const outPath = path.join(dir, path.basename(filePath, ext) + suffix + (options.format === "ts" ? ".ts" : ".js"));
     if (verbose) {
       console.log(`Compiling ${filePath} -> ${outPath}`);
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -288,7 +288,7 @@ export function main() {
   commander
   .description("Create runtime validator module from TypeScript interfaces")
   .usage("[options] <typescript-file...>")
-  .option("--format <format>", `Format to use for output; options are 'ts', 'js:esm', 'js:cjs'`)
+  .option("--format <format>", `Format to use for output; options are 'ts' (default), 'js:esm', 'js:cjs'`)
   .option("-g, --ignore-generics", `Ignores generics`)
   .option("-i, --ignore-index-signature", `Ignores index signature`)
   .option("--inline-imports", `Traverses the full import tree and inlines all types into output`)

--- a/test/fixtures/to-javascript-ti.cjs.js
+++ b/test/fixtures/to-javascript-ti.cjs.js
@@ -1,0 +1,13 @@
+const t = require("ts-interface-checker");
+
+module.exports = {
+  SomeInterface: t.iface([], {
+    "foo": "number",
+  }),
+
+  SomeEnum: t.enumtype({
+    "Foo": 0,
+  }),
+
+  SomeAlias: t.name("number"),
+};

--- a/test/fixtures/to-javascript-ti.esm.js
+++ b/test/fixtures/to-javascript-ti.esm.js
@@ -1,0 +1,18 @@
+import * as t from "ts-interface-checker";
+
+export const SomeInterface = t.iface([], {
+  "foo": "number",
+});
+
+export const SomeEnum = t.enumtype({
+  "Foo": 0,
+});
+
+export const SomeAlias = t.name("number");
+
+const exportedTypeSuite = {
+  SomeInterface,
+  SomeEnum,
+  SomeAlias,
+};
+export default exportedTypeSuite;

--- a/test/fixtures/to-javascript.ts
+++ b/test/fixtures/to-javascript.ts
@@ -1,0 +1,7 @@
+export interface SomeInterface {
+  foo: number
+}
+
+export enum SomeEnum { Foo }
+
+export type SomeAlias = number;

--- a/test/test_index.ts
+++ b/test/test_index.ts
@@ -56,4 +56,18 @@ describe("ts-interface-builder", () => {
     const expected = await readFile(join(fixtures, "imports-parent-shallow-ti.ts"), { encoding: "utf8" });
     assert.deepEqual(output, expected);
   });
+
+  it("should compile to JS in esm module format", async () => {
+    const output = await Compiler.compile(join(fixtures, "to-javascript.ts"),
+        {format: 'js:esm'});
+    const expected = await readFile(join(fixtures, "to-javascript-ti.esm.js"), {encoding: "utf8"});
+    assert.equal(output, expected);
+  });
+
+  it("should compile to JS in cjs module format", async () => {
+    const output = await Compiler.compile(join(fixtures, "to-javascript.ts"),
+        {format: 'js:cjs'});
+    const expected = await readFile(join(fixtures, "to-javascript-ti.cjs.js"), {encoding: "utf8"});
+    assert.equal(output, expected);
+  });
 });


### PR DESCRIPTION
Closes #12 with the approach I described in this comment: https://github.com/gristlabs/ts-interface-builder/issues/12#issuecomment-667356795

/cc @dsagal 

### Checklist
- [X] ~~Review code changes (@dsagal)~~
- [X] Update README documentation (@zenflow)
- [ ] Final PR review (@dsagal)