### PR TITLE
Fix TS compiler errors in lib/macro.ts

### DIFF
--- a/lib/macro.ts
+++ b/lib/macro.ts
@@ -30,7 +30,7 @@ const macroHandler: MacroHandler = (params) => {
   if (!somePath) {
     return;
   }
-  const programPath = somePath.findParent((path) => path.isProgram());
+  const programPath = somePath.findParent((path) => path.isProgram())!;
 
   const registry = new RequirementRegistry();
   const toReplace = [


### PR DESCRIPTION
It seems that we have some breakage in `master` due to newer releases of packages listed in package.json. 

If you rerun CI for the latest code in `master`, you should get the same TS compiler errors as seen in the CI run for #30: https://travis-ci.org/github/gristlabs/ts-interface-builder/jobs/738261161

This PR fixes those TS compiler errors.